### PR TITLE
Allow user to chose either AKS or ACS

### DIFF
--- a/generators/app/prompt.js
+++ b/generators/app/prompt.js
@@ -201,12 +201,13 @@ function applicationName(obj) {
 }
 
 function target(obj) {
+   var isKube = obj.hasOwnProperty('kube');
    return {
       name: `target`,
       type: `list`,
       store: true,
       message: `Where would you like to deploy?`,
-      choices: util.getTargets,
+      choices: isKube ? util.getKubeTargets :util.getTargets,
       when: answers => {
          return obj.options.target === undefined;
       }

--- a/generators/app/utility.js
+++ b/generators/app/utility.js
@@ -136,6 +136,21 @@ function getTargets(answers) {
    });
 }
 
+function getKubeTargets(answers){
+   return new Promise(function (resolve, reject) {
+      let targets = [];
+
+         targets = [{
+            name: `Azure Kubernetes Services`,
+            value: `aks`
+         }, {
+            name: `Azure Container Services`,
+            value: `acs`
+         }];
+      resolve(targets);
+   });
+}
+
 function getAppTypes(answers) {
    // Default to languages that work on all agents
    let types = [{
@@ -1163,6 +1178,7 @@ module.exports = {
    getFullURL: getFullURL,
    logMessage: logMessage,
    getTargets: getTargets,
+   getKubeTargets: getKubeTargets,
    getAppTypes: getAppTypes,
    checkStatus: checkStatus,
    findProject: findProject,

--- a/generators/k8helmpipeline/index.js
+++ b/generators/k8helmpipeline/index.js
@@ -12,6 +12,8 @@ module.exports = class extends Generator {
       // Calling the super constructor is important so our generator is correctly set up
       super(args, opts);
 
+      this.kube = true;
+
       // Order is important
       // These are position based arguments for this generator. If they are not provided
       // via the command line they will be queried during the prompting priority


### PR DESCRIPTION
Added an attribute to the Generator denoting it is using the Kubernetes pipeline. This allows for AKS or ACS to be chosen as the target deployment. 